### PR TITLE
添加 skip_save_worlds 配置项以兼容 Folia 及其下游分支的备份

### DIFF
--- a/prime_backup/action/create_backup_action.py
+++ b/prime_backup/action/create_backup_action.py
@@ -318,7 +318,7 @@ class CreateBackupAction(CreateBackupActionBase):
 		src_path_md5 = hashlib.md5(src_path_str.encode('utf8')).hexdigest()
 
 		@contextlib.contextmanager
-		def make_temp_file() -> ContextManager[Path]:
+		def make_temp_file(): # def make_temp_file() -> ContextManager[Path]:
 			temp_file_name = f'blob_{os.getpid()}_{threading.current_thread().ident}_{src_path_md5}.tmp'
 			temp_file_path = self.__temp_path / temp_file_name
 			try:

--- a/prime_backup/config/server_config.py
+++ b/prime_backup/config/server_config.py
@@ -14,6 +14,7 @@ class MinecraftServerCommands(Serializable):
 
 class ServerConfig(Serializable):
 	turn_off_auto_save: bool = True
+	skip_save_worlds: bool = False
 	commands: MinecraftServerCommands = MinecraftServerCommands()
 	saved_world_regex: List[re.Pattern] = [
 		re.compile('Saved the game'),

--- a/prime_backup/mcdr/task/backup/create_backup_task.py
+++ b/prime_backup/mcdr/task/backup/create_backup_task.py
@@ -35,13 +35,13 @@ class CreateBackupTask(HeavyTask[None]):
 		try:
 			timer = Timer()
 			if self.server.is_server_running():
-				if len(cmds.save_all_worlds) > 0:
+				if not self.config.server.skip_save_worlds and len(cmds.save_all_worlds) > 0:
 					self.server.execute(cmds.save_all_worlds)
-				if len(self.config.server.saved_world_regex) > 0:
-					ok = self.world_saved_done.wait(timeout=self.config.server.save_world_max_wait.value)
-					if not ok:
-						self.broadcast(self.tr('abort.save_wait_time_out').set_color(RColor.red))
-						return
+					if len(self.config.server.saved_world_regex) > 0:
+						ok = self.world_saved_done.wait(timeout=self.config.server.save_world_max_wait.value)
+						if not ok:
+							self.broadcast(self.tr('abort.save_wait_time_out').set_color(RColor.red))
+							return
 			cost_save_wait = timer.get_and_restart()
 			if self.plugin_unloaded_event.is_set():
 				self.broadcast(self.tr('abort.unloaded').set_color(RColor.red))


### PR DESCRIPTION
- 由于 Folia 对原版的破坏性改动，save-all 相关命令已经被禁用，所以无法在备份前运行 save-all flush 命令
- Folia 的区块会在卸载时自动保存，所以不需要运行 save-all flush 也可以进行备份操作