### PR TITLE
fix: scheduled backup trigger conditions

### DIFF
--- a/prime_backup/mcdr/online_player_counter.py
+++ b/prime_backup/mcdr/online_player_counter.py
@@ -40,28 +40,37 @@ class OnlinePlayerCounter:
 		self.data_lock = threading.Lock()
 		self.data_is_correct = False
 		self.job_data_store = {}
-		self.player_list: _PlayerList = []
+		self.online_player_list: _PlayerList = []
+		self.player_record_list: _PlayerList = []
 
-	def get_online_players(self) -> Optional[GetOnlinePlayersResult]:
-		def filter_for(players: _PlayerList):
-			blacklist = self.config.scheduled_backup.require_online_players_blacklist
-			result = GetOnlinePlayersResult()
-			for player in players:
-				ok = all(map(
-					lambda pattern: not pattern.fullmatch(player),
-					blacklist
-				))
-				result.all.append(player)
-				if ok:
-					result.valid.append(player)
-				else:
-					result.ignored.append(player)
+	def filtered_players(self, players: _PlayerList):
+		blacklist = self.config.scheduled_backup.require_online_players_blacklist
+		result = GetOnlinePlayersResult()
+		for player in players:
+			ok = all(map(lambda pattern: not pattern.fullmatch(player), blacklist))
+			result.all.append(player)
+			if ok:
+				result.valid.append(player)
+			else:
+				result.ignored.append(player)
 
-			return result
+		return result
 
+	def reset_player_records(self):
+		with self.data_lock:
+			self.player_record_list = self.online_player_list.copy()
+
+	def get_player_records(self) -> Optional[GetOnlinePlayersResult]:
 		with self.data_lock:
 			if self.data_is_correct:
-				return filter_for(self.player_list)
+				return self.filtered_players(self.player_record_list)
+			else:
+				return None
+
+	def get_online_players(self) -> Optional[GetOnlinePlayersResult]:
+		with self.data_lock:
+			if self.data_is_correct:
+				return self.filtered_players(self.online_player_list)
 			else:
 				return None
 
@@ -85,7 +94,8 @@ class OnlinePlayerCounter:
 
 			with self.data_lock:
 				self.data_is_correct = True
-				self.player_list = player_names
+				self.online_player_list = player_names.copy()
+				self.player_record_list = player_names.copy()
 
 			if log_success:
 				self.logger.info('Successfully queried online players from minecraft_data_api: {}'.format(player_names))
@@ -102,21 +112,26 @@ class OnlinePlayerCounter:
 	def __on_load(self, prev: Any, should_update_from_api: bool):
 		if (prev_lock := getattr(prev, 'data_lock', None)) is not None and type(prev_lock) is type(self.data_lock):
 			with prev_lock:
-				prev_data_is_correct = getattr(prev, 'data_is_correct', False)
-				prev_player_list = getattr(prev, 'player_list', None)
-				if isinstance(prev_player_list, list):
-					prev_player_list = prev_player_list.copy()
+				prev_data_is_correct = getattr(prev, "data_is_correct", False)
+				prev_online_player_list = getattr(prev, "online_player_list", None)
+				prev_player_record_list = getattr(prev, "player_record_list", None)
+				if isinstance(prev_online_player_list, list):
+					prev_online_player_list = prev_online_player_list.copy()
+				if isinstance(prev_player_record_list, list):
+					prev_player_record_list = prev_player_record_list.copy()
 
-				self.job_data_store = getattr(prev, 'job_data_store', {})
+				self.job_data_store = getattr(prev, "job_data_store", {})
 		else:
 			prev_data_is_correct = False
-			prev_player_list = None
+			prev_online_player_list = None
+			prev_player_record_list = None
 
-		if prev_data_is_correct is True and prev_player_list is not None:
+		if prev_data_is_correct is True and prev_online_player_list is not None:
 			self.logger.info('Found existing valid data of the previous online player counter, inherit it')
 			with self.data_lock:
 				self.data_is_correct = True
-				self.player_list = prev_player_list
+				self.online_player_list = prev_online_player_list
+				self.player_record_list = prev_player_record_list
 		elif should_update_from_api and self.server.is_server_startup():
 			self.__try_update_player_list_from_api(log_success=True)
 
@@ -124,18 +139,21 @@ class OnlinePlayerCounter:
 		self.logger.debug(f'Server {what} detected, enable the online player counter')
 		with self.data_lock:
 			self.data_is_correct = True
-			self.player_list = []
+			self.online_player_list = []
+			self.player_record_list = []
 
 	def on_player_joined(self, player: str):
 		with self.data_lock:
 			if self.data_is_correct:
-				if player not in self.player_list:
-					self.player_list.append(player)
+				if player not in self.online_player_list:
+					self.online_player_list.append(player)
+				if player not in self.player_record_list:
+					self.player_record_list.append(player)
 
 	def on_player_left(self, player: str):
 		with self.data_lock:
 			if self.data_is_correct:
 				try:
-					self.player_list.remove(player)
+					self.online_player_list.remove(player)
 				except ValueError:
-					self.logger.warning('Tried to remove not-existed player {} from player list {}, data desync?'.format(player, self.player_list))
+					self.logger.warning('Tried to remove not-existed player {} from player list {}, data desync?'.format(player, self.online_player_list))

--- a/prime_backup/mcdr/online_player_counter.py
+++ b/prime_backup/mcdr/online_player_counter.py
@@ -9,16 +9,14 @@ from prime_backup import logger
 from prime_backup.config.config import Config
 from prime_backup.utils import misc_utils
 
-_PlayerList = List[str]
-
 
 @dataclasses.dataclass(frozen=True)
-class GetOnlinePlayersResult:
-	all: _PlayerList = dataclasses.field(default_factory=list)
-	valid: _PlayerList = dataclasses.field(default_factory=list)
-	ignored: _PlayerList = dataclasses.field(default_factory=list)
+class PlayerRecord:
+	name: str
+	online: bool
+	valid: bool
 
-
+_PlayerDict = dict[str, PlayerRecord]
 class OnlinePlayerCounter:
 	__inst: Optional['OnlinePlayerCounter'] = None
 
@@ -40,47 +38,42 @@ class OnlinePlayerCounter:
 		self.data_lock = threading.Lock()
 		self.data_is_correct = False
 		self.job_data_store = {}
-		self.online_player_list: _PlayerList = []
-		self.player_record_list: _PlayerList = []
+		self.player_dict: _PlayerDict = {}
 
-	def filtered_players(self, players: _PlayerList):
+	def __is_valid_player(self, player_name: str) -> bool:
 		blacklist = self.config.scheduled_backup.require_online_players_blacklist
-		result = GetOnlinePlayersResult()
-		for player in players:
-			ok = all(map(lambda pattern: not pattern.fullmatch(player), blacklist))
-			result.all.append(player)
-			if ok:
-				result.valid.append(player)
-			else:
-				result.ignored.append(player)
+		for pattern in blacklist:
+			if not pattern.fullmatch(player_name):
+				return False
 
-		return result
+		return True
+
+	def get_player_records(self) -> Optional[_PlayerDict]:
+		with self.data_lock:
+			if self.data_is_correct:
+				# deepcopy is not needed here, since PlayerRecord is immutable
+				return self.player_dict.copy()
+			else:
+				return None
 
 	def reset_player_records(self):
 		with self.data_lock:
-			self.player_record_list = self.online_player_list.copy()
-
-	def get_player_records(self) -> Optional[GetOnlinePlayersResult]:
-		with self.data_lock:
 			if self.data_is_correct:
-				return self.filtered_players(self.player_record_list)
-			else:
-				return None
+				self.player_dict = {
+					name: player_record
+					for name, player_record in self.player_dict.items()
+					if player_record.online
+				}
 
-	def get_online_players(self) -> Optional[GetOnlinePlayersResult]:
-		with self.data_lock:
-			if self.data_is_correct:
-				return self.filtered_players(self.online_player_list)
-			else:
-				return None
-
-	def __try_update_player_list_from_api(self, *, log_success: bool = False, timeout: float = 10):
-		api = self.server.get_plugin_instance('minecraft_data_api')
+	def __try_update_player_dict_from_api(
+		self, *, log_success: bool = False, timeout: float = 10
+	):
+		api = self.server.get_plugin_instance("minecraft_data_api")
 		if api is None:
 			return None
 
 		def query_thread():
-			player_names: _PlayerList = []
+			player_names: List[str] = []
 			try:
 				result = api.get_server_player_list(timeout=timeout)
 				if result is not None:
@@ -89,13 +82,19 @@ class OnlinePlayerCounter:
 				self.logger.exception('Queried players from minecraft_data_api error', e)
 				return None
 			if result is None:
-				self.logger.warning('Queried players from minecraft_data_api failed')
+				self.logger.warning("Queried players from minecraft_data_api failed")
 				return None
 
 			with self.data_lock:
 				self.data_is_correct = True
-				self.online_player_list = player_names.copy()
-				self.player_record_list = player_names.copy()
+				self.player_dict = {
+					name: PlayerRecord(
+						name=name,
+						online=True,
+						valid=self.__is_valid_player(name),
+					)
+					for name in player_names
+				}
 
 			if log_success:
 				self.logger.info('Successfully queried online players from minecraft_data_api: {}'.format(player_names))
@@ -107,53 +106,75 @@ class OnlinePlayerCounter:
 		should_update_from_api = self.server.is_server_startup()
 
 		# delay this for a little bit, in case minecraft_data_api is loading too
-		self.server.schedule_task(functools.partial(self.__on_load, prev, should_update_from_api))
+		self.server.schedule_task(
+			functools.partial(self.__on_load, prev, should_update_from_api)
+		)
 
 	def __on_load(self, prev: Any, should_update_from_api: bool):
-		if (prev_lock := getattr(prev, 'data_lock', None)) is not None and type(prev_lock) is type(self.data_lock):
+		if (prev_lock := getattr(prev, "data_lock", None)) is not None and type(
+			prev_lock
+		) is type(self.data_lock):
 			with prev_lock:
 				prev_data_is_correct = getattr(prev, "data_is_correct", False)
-				prev_online_player_list = getattr(prev, "online_player_list", None)
-				prev_player_record_list = getattr(prev, "player_record_list", None)
-				if isinstance(prev_online_player_list, list):
-					prev_online_player_list = prev_online_player_list.copy()
-				if isinstance(prev_player_record_list, list):
-					prev_player_record_list = prev_player_record_list.copy()
+				prev_player_dict: _PlayerDict = getattr(prev, "player_dict", None)
+				if not isinstance(prev_player_dict, dict) or not all(
+					isinstance(record, PlayerRecord)
+					for record in prev_player_dict.values()
+				):
+					prev_data_is_correct = False
+					prev_player_dict = None
 
 				self.job_data_store = getattr(prev, "job_data_store", {})
 		else:
 			prev_data_is_correct = False
-			prev_online_player_list = None
-			prev_player_record_list = None
+			prev_player_dict = None
 
-		if prev_data_is_correct is True and prev_online_player_list is not None:
+		if prev_data_is_correct is True and prev_player_dict is not None:
 			self.logger.info('Found existing valid data of the previous online player counter, inherit it')
 			with self.data_lock:
 				self.data_is_correct = True
-				self.online_player_list = prev_online_player_list
-				self.player_record_list = prev_player_record_list
+				self.player_dict = {
+					name: PlayerRecord(
+						name=player.name,
+						online=player.online,
+						# Re-validate player name
+						valid=self.__is_valid_player(player.name),
+					)
+					for name, player in prev_player_dict.items()
+				}
 		elif should_update_from_api and self.server.is_server_startup():
-			self.__try_update_player_list_from_api(log_success=True)
+			self.__try_update_player_dict_from_api(log_success=True)
 
 	def on_server_start_stop(self, what: str):
-		self.logger.debug(f'Server {what} detected, enable the online player counter')
+		self.logger.debug(f"Server {what} detected, enable the online player counter")
 		with self.data_lock:
 			self.data_is_correct = True
-			self.online_player_list = []
-			self.player_record_list = []
+			self.player_dict = {}
 
-	def on_player_joined(self, player: str):
+	def on_player_joined(self, player_name: str):
 		with self.data_lock:
 			if self.data_is_correct:
-				if player not in self.online_player_list:
-					self.online_player_list.append(player)
-				if player not in self.player_record_list:
-					self.player_record_list.append(player)
+				if player_name not in self.player_dict:
+					self.player_dict[player_name] = PlayerRecord(
+						name=player_name,
+						online=True,
+						valid=self.__is_valid_player(player_name),
+					)
+				else:
+					self.player_dict[player_name] = dataclasses.replace(
+						self.player_dict[player_name], online=True
+					)
 
 	def on_player_left(self, player: str):
 		with self.data_lock:
 			if self.data_is_correct:
-				try:
-					self.online_player_list.remove(player)
-				except ValueError:
-					self.logger.warning('Tried to remove not-existed player {} from player list {}, data desync?'.format(player, self.online_player_list))
+				if player in self.player_dict:
+					self.player_dict[player] = dataclasses.replace(
+						self.player_dict[player], online=False
+					)
+				else:
+					self.logger.warning(
+						"Tried to mark non-existent player {} as offline from player dict {}, data desync?".format(
+							player, self.player_dict
+						)
+					)


### PR DESCRIPTION
Assume that the server is backed up every hour, and the last task runs at 00:00. At this time, no player is online. Make the last backup or no backup. A player entered at 00:01, played for 30 minutes, and exited the server at 00:31. Then the original logic cannot detect the online player at 01:00 and will not be backed up