### PR TITLE
feat: 备份/回档任务通知推送（Webhook + Bark 原生支持）与中英文文档

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,8 @@ This is the root json object in the config files
     "backup": {/* Backup config */},
     "scheduled_backup": {/* Scheduled backup config */},
     "prune": {/* Prune config */},
-    "database": {/* Database config */}
+    "database": {/* Database config */},
+    "notification": {/* Notification config */}
 }
 ```
 
@@ -83,7 +84,8 @@ A value of `0` means using 50% of the CPU
         "prune": 3,
         "rename": 2,
         "show": 1,
-        "tag": 3
+        "tag": 3,
+        "test": 4
     },
     "confirm_time_wait": "1m",
     "backup_on_restore": true,
@@ -744,6 +746,90 @@ Database backups are stored with the `.tar.xz` format, and won't take up much sp
 See the [crontab job setting](#crontab-job-setting) section
 
 ---
+
+### Notification config
+
+Configuration for backup/restore notification push. When enabled, Prime Backup sends webhook or Bark notifications on task start/success/failure
+
+```json
+{
+    "enabled": false,
+    "events": [
+        "backup_start",
+        "backup_success",
+        "backup_failure",
+        "restore_start",
+        "restore_success",
+        "restore_failure"
+    ],
+    "endpoints": [
+        {
+            "enabled": true,
+            "name": "webhook",
+            "type": "webhook",
+            "url": "https://example.com/webhook",
+            "headers": {
+                "Authorization": "Bearer token"
+            },
+            "timeout": "5s"
+        }
+    ]
+}
+```
+
+#### enabled
+
+Notification switch
+
+- Type: `bool`
+- Default: `false`
+
+#### events
+
+Event types to notify
+
+- `backup_start`
+- `backup_success`
+- `backup_failure`
+- `restore_start`
+- `restore_success`
+- `restore_failure`
+
+- Type: `List[str]`
+
+#### endpoints
+
+Notification endpoint list. Each endpoint receives a notification on selected events
+
+- Type: `List[NotificationEndpoint]`
+
+##### NotificationEndpoint
+
+- `enabled`: enable the endpoint (`bool`, default `true`)
+- `name`: endpoint name (`str`, default `"default"`)
+- `type`: `webhook` or `bark` (`str`, default `"webhook"`)
+- `url`: target URL (`str`)
+- `headers`: extra request headers (`Dict[str, str]`, default `{}`)
+- `timeout`: request timeout ([`Duration`](#duration), default `"5s"`)
+- `bark`: Bark options (see below)
+
+###### Bark options
+
+`bark` is only used when `type = "bark"`. Common fields (all optional):
+
+- `device_key`
+- `title` / `subtitle` / `body` / `markdown`
+- `group` / `sound` / `level` / `badge` / `icon` / `image`
+- `url` / `action` / `copy` / `autoCopy`
+- `id` / `delete` / `isArchive` / `volume` / `call`
+
+By default, `bark.level` is derived from task result: success `passive`, failure `critical`, start/others `active`
+
+#### Payload
+
+For `type = webhook`, Prime Backup sends the full JSON payload described in [Task Notifications & Webhook](feature/notification.md)
+
+For `type = bark`, Prime Backup sends Bark native JSON fields instead of the full payload
 
 ## Subconfig types
 

--- a/docs/config.zh.md
+++ b/docs/config.zh.md
@@ -23,7 +23,8 @@ title: '配置文件'
     "backup": {/* 备份配置 */},
     "scheduled_backup": {/* 定时备份配置 */},
     "prune": {/* 修剪配置 */},
-    "database": {/* 数据库配置 */}
+    "database": {/* 数据库配置 */},
+    "notification": {/* 通知配置 */}
 }
 ```
 
@@ -745,6 +746,106 @@ Prime Backup 所使用的 SQLite 数据库的相关配置
 见 [定时作业配置](#定时作业配置) 小节
 
 --- 
+
+### 通知配置
+
+备份/回档任务的事件推送配置。启用后，Prime Backup 会在任务开始、成功、失败时向指定的 Webhook 发送 JSON 请求
+
+```json
+{
+    "enabled": false,
+    "events": [
+        "backup_start",
+        "backup_success",
+        "backup_failure",
+        "restore_start",
+        "restore_success",
+        "restore_failure"
+    ],
+    "endpoints": [
+        {
+            "enabled": true,
+            "name": "webhook",
+            "type": "webhook",
+            "url": "https://example.com/webhook",
+            "headers": {
+                "Authorization": "Bearer token"
+            },
+            "timeout": "5s"
+        }
+    ]
+}
+```
+
+#### enabled
+
+通知功能开关
+
+- 类型：`bool`
+- 默认值：`false`
+
+#### events
+
+需要触发通知的事件类型列表
+
+可用值：
+
+- `backup_start`
+- `backup_success`
+- `backup_failure`
+- `restore_start`
+- `restore_success`
+- `restore_failure`
+
+- 类型：`List[str]`
+
+#### endpoints
+
+通知目标列表。每个目标会接收相同的 JSON Payload
+
+- 类型：`List[NotificationEndpoint]`
+
+##### NotificationEndpoint
+
+- `enabled`：是否启用该 Endpoint（`bool`，默认 `true`）
+- `name`：Endpoint 名称（`str`，默认 `"default"`）
+- `type`：Endpoint 类型，`webhook` 或 `bark`（`str`，默认 `"webhook"`）
+- `url`：目标地址（`str`）
+- `headers`：额外请求头（`Dict[str, str]`，默认 `{}`）
+- `timeout`：请求超时（[`Duration`](#duration)，默认 `"5s"`）
+- `bark`：Bark 专用参数（见下）
+
+###### Bark 参数
+
+`bark` 仅在 `type = "bark"` 时生效。常用字段如下（均为可选）：
+
+- `device_key`：设备 key（用于 `/push` 或 URL 占位符）
+- `title` / `subtitle` / `body` / `markdown`
+- `group` / `sound` / `level` / `badge` / `icon` / `image`
+- `url` / `action` / `copy` / `autoCopy`
+- `id` / `delete` / `isArchive` / `volume` / `call`
+
+默认情况下，`bark.level` 会按任务结果自动设置：成功 `passive`、失败 `critical`、开始/其他 `active`
+
+#### Payload 说明
+
+请求方法为 `POST`，内容类型为 `application/json`
+
+Payload 中包含以下常用字段：
+
+- `event`：事件类型，如 `backup_success`
+- `task`：任务类型（`backup` / `restore`）
+- `status`：状态（`start` / `success` / `failure`）
+- `timestamp`：时间戳（`unix` 与 `iso`）
+- `backup`：备份信息（id、comment、date、tags、大小等）
+- `operator` / `source`：操作者与触发来源
+- `message` / `error`：失败原因或异常信息（如有）
+
+`type = bark` 时，将使用 Bark 原生 JSON 字段（见 Bark 文档），不发送上述完整 payload
+
+完整示例见 [任务通知与 Webhook](feature/notification.zh.md)
+
+---
 
 ## 子配置项说明
 

--- a/docs/feature/index.md
+++ b/docs/feature/index.md
@@ -11,6 +11,7 @@ Prime Backup feature list
 - [Backup display](backup_display.md)
 - [Backup edit](backup_edit.md)
 - [Backup import/export](backup_import.md)
+- [Task Notifications & Webhook](notification.md)
 
 ### Scheduled Jobs
 

--- a/docs/feature/index.zh.md
+++ b/docs/feature/index.zh.md
@@ -11,6 +11,7 @@ Prime Backup 主要功能概览
 - [备份展示](backup_display.zh.md)
 - [备份编辑](backup_edit.zh.md)
 - [备份导入导出](backup_import.zh.md)
+- [任务通知与 Webhook](notification.zh.md)
 
 ### 定时任务
 

--- a/docs/feature/notification.md
+++ b/docs/feature/notification.md
@@ -1,0 +1,117 @@
+---
+title: 'Task Notifications & Webhook'
+---
+
+Prime Backup can push notifications for backup/restore lifecycle events, which is useful for unattended ops
+
+## Supported events
+
+- `backup_start`
+- `backup_success`
+- `backup_failure`
+- `restore_start`
+- `restore_success`
+- `restore_failure`
+
+## Configuration example
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": [
+            "backup_start",
+            "backup_success",
+            "backup_failure",
+            "restore_start",
+            "restore_success",
+            "restore_failure"
+        ],
+        "endpoints": [
+            {
+                "enabled": true,
+                "name": "webhook",
+                "type": "webhook",
+                "url": "https://example.com/webhook",
+                "headers": {
+                    "Authorization": "Bearer token"
+                },
+                "timeout": "5s"
+            }
+        ]
+    }
+}
+```
+
+## Payload
+
+For `type = webhook`, Prime Backup sends a JSON payload that includes:
+
+- `event`, `task`, `status`
+- `timestamp`
+- `backup` (id/comment/date/tags/size)
+- `operator` / `source`
+- `message` / `error`
+- `title` / `body` / `desp`
+
+## Bark
+
+Prime Backup has native Bark support. Set endpoint `type` to `bark`
+
+Key in URL (recommended):
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": ["backup_success", "backup_failure"],
+        "endpoints": [
+            {
+                "name": "bark",
+                "type": "bark",
+                "url": "https://api.day.app/<your_key>",
+                "timeout": "5s"
+            }
+        ]
+    }
+}
+```
+
+Using `/push` + `device_key`:
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": ["backup_success", "backup_failure"],
+        "endpoints": [
+            {
+                "name": "bark",
+                "type": "bark",
+                "url": "https://api.day.app/push",
+                "timeout": "5s",
+                "bark": {
+                    "device_key": "<your_key>",
+                    "group": "prime_backup",
+                    "level": "timeSensitive",
+                    "sound": "minuet",
+                    "badge": 1
+                }
+            }
+        ]
+    }
+}
+```
+
+Bark body defaults to ops-friendly details, and levels are mapped automatically:
+
+- success: `passive`
+- failure: `critical`
+- start/others: `active`
+
+You can override with `bark.level` or `bark.body` / `bark.markdown`
+
+## Test notification
+
+- `!!pb test notify`
+- `!!pb test notify <event>`

--- a/docs/feature/notification.zh.md
+++ b/docs/feature/notification.zh.md
@@ -1,0 +1,186 @@
+---
+title: '任务通知与 Webhook'
+---
+
+Prime Backup 支持在备份/回档任务的关键节点主动推送通知，便于无人值守或自动化运维场景下及时获知任务状态
+
+## 支持的事件类型
+
+- `backup_start`：备份开始
+- `backup_success`：备份成功
+- `backup_failure`：备份失败
+- `restore_start`：回档开始
+- `restore_success`：回档成功
+- `restore_failure`：回档失败
+
+## 配置示例
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": [
+            "backup_start",
+            "backup_success",
+            "backup_failure",
+            "restore_start",
+            "restore_success",
+            "restore_failure"
+        ],
+        "endpoints": [
+            {
+                "enabled": true,
+                "name": "webhook",
+                "type": "webhook",
+                "url": "https://example.com/webhook",
+                "headers": {
+                    "Authorization": "Bearer token"
+                },
+                "timeout": "5s"
+            }
+        ]
+    }
+}
+```
+
+## Payload 结构
+
+Webhook 使用 `POST` JSON 请求，常见字段如下：
+
+- `event`：事件类型
+- `task`：任务类型（`backup` / `restore`）
+- `status`：状态（`start` / `success` / `failure`）
+- `timestamp`：时间戳（`unix` 与 `iso`）
+- `backup`：备份信息（id、comment、date、tags、大小等）
+- `operator` / `source`：操作者与触发来源
+- `message` / `error`：失败原因或异常信息（如有）
+- `title` / `body` / `desp`：便于第三方服务直接展示的简要内容
+
+## 推送通道与负载说明
+
+- `type = webhook`：发送完整 Prime Backup JSON payload（用于通用 Webhook）
+- `type = bark`：发送 Bark 原生 JSON payload（字段名与 Bark 接口一致）
+
+### Bark 负载默认规则
+
+- 默认会根据任务内容生成 `title` / `body`
+- `body` 会包含运维关键信息（事件/状态/备份ID/注释/操作者/耗时/错误等）
+- 默认等级：成功 `passive`，失败 `critical`，开始/其他 `active`
+
+## 与常见服务集成
+
+### Bark
+
+Prime Backup 已提供 Bark 原生支持，无需中转 Webhook。配置时将 Endpoint 的 `type` 设为 `bark` 即可
+
+推荐使用 **Key 放在 URL 路径** 的方式（无需 `device_key` 字段）：
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": ["backup_success", "backup_failure"],
+        "endpoints": [
+            {
+                "name": "bark",
+                "type": "bark",
+                "url": "https://api.day.app/<your_key>",
+                "timeout": "5s"
+            }
+        ]
+    }
+}
+```
+
+适合运维的高级配置示例（Bark 原生字段）：
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": ["backup_start", "backup_success", "backup_failure", "restore_success", "restore_failure"],
+        "endpoints": [
+            {
+                "name": "bark",
+                "type": "bark",
+                "url": "https://api.day.app/<your_key>",
+                "timeout": "5s",
+                "bark": {
+                    "group": "prime_backup",
+                    "sound": "minuet",
+                    "badge": 1,
+                    "url": "https://example.com/ops/runbook",
+                    "icon": "https://example.com/icon.png"
+                }
+            }
+        ]
+    }
+}
+```
+
+若使用 `/push` 形式，可在 `bark.device_key` 中提供 key：
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": ["backup_success", "backup_failure"],
+        "endpoints": [
+            {
+                "name": "bark",
+                "type": "bark",
+                "url": "https://api.day.app/push",
+                "timeout": "5s",
+                "bark": {
+                    "device_key": "<your_key>",
+                    "group": "prime_backup",
+                    "level": "timeSensitive",
+                    "sound": "minuet",
+                    "badge": 1
+                }
+            }
+        ]
+    }
+}
+```
+
+`bark` 中支持 Bark 的大部分参数（如 `group` / `sound` / `level` / `badge` / `icon` / `url` / `id` / `delete` 等），
+Prime Backup 会将 `title` / `body` 自动填入（也可通过 `bark.title` / `bark.body` 覆盖）
+
+为便于运维查看，Bark 的 `body` 默认会包含关键字段（事件、状态、备份ID、注释、操作者、耗时、错误等），
+且会根据结果自动设置通知等级：
+
+- 成功：`passive`
+- 失败：`critical`
+- 开始/其他：`active`
+
+如需自定义，可显式设置 `bark.level` 或覆盖 `bark.body` / `bark.markdown`
+
+## 测试通知
+
+可使用命令发送测试通知：
+
+- `!!pb test notify`
+- `!!pb test notify <event>`
+
+### Server酱
+
+Server酱的 API 通常使用 `title` 与 `desp` 字段，Prime Backup 的 Payload 会同时提供这些字段：
+
+```json
+{
+    "notification": {
+        "enabled": true,
+        "events": ["backup_success", "backup_failure"],
+        "endpoints": [
+            {
+                "name": "serverchan",
+                "url": "https://sctapi.ftqq.com/<your_key>.send",
+                "timeout": "5s"
+            }
+        ]
+    }
+}
+```
+
+如需更复杂的格式或自定义字段，可使用中转 Webhook 服务进行二次处理

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -168,6 +168,11 @@ Here are a few important things in the config file:
 
 Now Prime Backup should start working
 
+### Optional: task notifications
+
+If you want push notifications for backup/restore events, enable the notification config.
+See [Notification config](config.md#notification-config) and [Task Notifications & Webhook](feature/notification.md)
+
 ## Use
 
 Enter `!!pb` in the MCDR console, or in game, you should see the welcome page as shown below

--- a/docs/quick_start.zh.md
+++ b/docs/quick_start.zh.md
@@ -168,6 +168,11 @@ mcdr_root/
 
 现在 Prime Backup 应该开始工作了
 
+### 可选：任务通知推送
+
+如果你希望在备份/回档开始、成功或失败时收到消息推送，可以启用通知配置。
+请参考 [通知配置](config.zh.md#通知配置) 与 [任务通知与 Webhook](feature/notification.zh.md) 文档
+
 ## 使用
 
 在 MCDR 控制台或游戏中输入 `!!pb`，你应该看到如下所示的欢迎页面

--- a/lang/en_us.yml
+++ b/lang/en_us.yml
@@ -15,6 +15,9 @@ prime_backup:
       noop: Nothing to abort
       no_permission: You don't have the permission to abort the current task
       not_abort_able: The current task {} is not abort-able
+    test_notify:
+      disabled: Notification is disabled or no endpoint configured
+      sent: Test notification sent (event: {})
 
   task:
     _base:

--- a/lang/en_us.yml
+++ b/lang/en_us.yml
@@ -365,6 +365,7 @@ prime_backup:
           §7{prefix} export §6<backup_id> §7[...]§r: Export the given backup. See §7{prefix} help export§r for detailed help
           §7{prefix} import §3<file_path> §7[...]§r: Import backup from an external file. See §7{prefix} help import§r for detailed help
           §7{prefix} prune §6<backup_id>§r: Manually trigger a backup prune
+           §7{prefix} test notify §7[<event>]§r: send a test notification
           §7{prefix} diff §6<backup_id_old> §6<backup_id_new>§r: Show file differences between two backups
           §7{prefix} crontab §a<job_id> §7[...]§r: Crontab job operations. See §7{prefix} help crontab§r for help
           §7{prefix} tag §6<backup_id> §7[...]§r: Tag operation on the given backup

--- a/lang/zh_cn.yml
+++ b/lang/zh_cn.yml
@@ -371,6 +371,7 @@ prime_backup:
           §7{prefix} database [...]§r: 操作数据库。详见§7{prefix} help database§r
           §7{prefix} confirm§r: 确认当前的任务操作
           §7{prefix} abort§r: 终止当前的任务操作
+          §7{prefix} test notify §7[<事件>]§r: 发送通知测试
       arguments:
         title: 【参数帮助】
         content: |-

--- a/lang/zh_cn.yml
+++ b/lang/zh_cn.yml
@@ -15,6 +15,9 @@ prime_backup:
       noop: 没有什么是需要终止的
       no_permission: 权限不足，无法终止当前任务
       not_abort_able: 当前任务{}无法被终止
+    test_notify:
+      disabled: 通知未启用或未配置推送地址
+      sent: 已发送测试通知（事件：{}）
 
   task:
     _base:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
     - feature/backup_display.md
     - feature/backup_edit.md
     - feature/backup_import.md
+    - feature/notification.md
     - feature/database_overview.md
     - feature/database_inspect.md
     - feature/database_maintain.md

--- a/prime_backup/config/command_config.py
+++ b/prime_backup/config/command_config.py
@@ -24,6 +24,7 @@ class CommandPermissions(Serializable):
 	rename: int = 2
 	show: int = 1
 	tag: int = 3
+	test: int = 4
 
 	def get(self, literal: str) -> int:
 		if literal.startswith('_'):

--- a/prime_backup/config/config.py
+++ b/prime_backup/config/config.py
@@ -12,6 +12,7 @@ from prime_backup.config.database_config import DatabaseConfig
 from prime_backup.config.prune_config import PruneConfig
 from prime_backup.config.scheduled_backup_config import ScheduledBackupConfig
 from prime_backup.config.server_config import ServerConfig
+from prime_backup.config.notification_config import NotificationConfig
 
 
 class Config(Serializable):
@@ -26,6 +27,7 @@ class Config(Serializable):
 	scheduled_backup: ScheduledBackupConfig = ScheduledBackupConfig()
 	prune: PruneConfig = PruneConfig()
 	database: DatabaseConfig = DatabaseConfig()
+	notification: NotificationConfig = NotificationConfig()
 
 	# ==================== Instance getters ====================
 

--- a/prime_backup/config/notification_config.py
+++ b/prime_backup/config/notification_config.py
@@ -1,0 +1,43 @@
+from typing import List, Dict
+
+from mcdreforged.api.utils import Serializable
+from typing_extensions import override
+
+from prime_backup.types.notification_event import NotificationEvent
+from prime_backup.types.units import Duration
+
+
+class NotificationEndpoint(Serializable):
+	enabled: bool = True
+	name: str = 'default'
+	url: str = ''
+	headers: Dict[str, str] = {}
+	timeout: Duration = Duration('5s')
+
+
+class NotificationConfig(Serializable):
+	enabled: bool = False
+	events: List[NotificationEvent] = [
+		NotificationEvent.backup_start,
+		NotificationEvent.backup_success,
+		NotificationEvent.backup_failure,
+		NotificationEvent.restore_start,
+		NotificationEvent.restore_success,
+		NotificationEvent.restore_failure,
+	]
+	endpoints: List[NotificationEndpoint] = []
+
+	@override
+	def on_deserialization(self, **kwargs):
+		normalized_events: List[NotificationEvent] = []
+		for item in self.events:
+			if isinstance(item, NotificationEvent):
+				normalized_events.append(item)
+			elif isinstance(item, str):
+				if item in NotificationEvent.__members__:
+					normalized_events.append(NotificationEvent[item])
+				else:
+					normalized_events.append(NotificationEvent(item))
+			else:
+				raise ValueError('bad notification event {!r}'.format(item))
+		self.events = normalized_events

--- a/prime_backup/config/notification_config.py
+++ b/prime_backup/config/notification_config.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from mcdreforged.api.utils import Serializable
 from typing_extensions import override
@@ -7,12 +7,43 @@ from prime_backup.types.notification_event import NotificationEvent
 from prime_backup.types.units import Duration
 
 
+class BarkOptions(Serializable):
+	device_key: Optional[str] = None
+	title: Optional[str] = None
+	subtitle: Optional[str] = None
+	body: Optional[str] = None
+	markdown: bool = False
+	level: Optional[str] = None
+	volume: Optional[int] = None
+	badge: Optional[int] = None
+	call: Optional[str] = None
+	autoCopy: Optional[str] = None
+	copy: Optional[str] = None
+	sound: Optional[str] = None
+	icon: Optional[str] = None
+	image: Optional[str] = None
+	group: Optional[str] = None
+	url: Optional[str] = None
+	action: Optional[str] = None
+	id: Optional[str] = None
+	delete: Optional[str] = None
+	isArchive: Optional[str] = None
+
+
 class NotificationEndpoint(Serializable):
 	enabled: bool = True
 	name: str = 'default'
+	type: str = 'webhook'  # webhook | bark
 	url: str = ''
 	headers: Dict[str, str] = {}
 	timeout: Duration = Duration('5s')
+	bark: BarkOptions = BarkOptions()
+
+	@override
+	def on_deserialization(self, **kwargs):
+		self.type = str(self.type).lower()
+		if self.type not in ['webhook', 'bark']:
+			raise ValueError('bad notification endpoint type {!r}'.format(self.type))
 
 
 class NotificationConfig(Serializable):

--- a/prime_backup/mcdr/command/commands.py
+++ b/prime_backup/mcdr/command/commands.py
@@ -45,8 +45,10 @@ from prime_backup.types.backup_filter import BackupFilter, BackupSortOrder
 from prime_backup.types.backup_tags import BackupTagName
 from prime_backup.types.hash_method import HashMethod
 from prime_backup.types.operator import Operator
+from prime_backup.types.notification_event import NotificationEvent
 from prime_backup.types.standalone_backup_format import StandaloneBackupFormat
 from prime_backup.utils import misc_utils
+from prime_backup.utils import notify_utils
 from prime_backup.utils.mcdr_utils import tr, reply_message, mkcmd
 
 
@@ -254,6 +256,20 @@ class CommandManager:
 
 	def cmd_abort(self, source: CommandSource, _: CommandContext):
 		self.task_manager.do_abort(source)
+
+	def cmd_test_notify(self, source: CommandSource, context: CommandContext):
+		config = Config.get().notification
+		if not config.enabled or len(config.endpoints) == 0:
+			reply_message(source, tr('command.test_notify.disabled').set_color(RColor.yellow))
+			return
+		event = context.get('event', NotificationEvent.backup_success)
+		notify_utils.notify(
+			event,
+			operator=Operator.of(source),
+			source=source,
+			message='manual_test',
+		)
+		reply_message(source, tr('command.test_notify.sent', event.value))
 
 	def cmd_show_backup_tag(self, source: CommandSource, context: CommandContext, tag_name: Optional[BackupTagName] = None):
 		def backup_id_consumer(backup_id: int):
@@ -550,6 +566,17 @@ class CommandManager:
 				node.then(children[0])
 			return create_subcommand('tag').then(node)
 
+		def make_test_cmd() -> Literal:
+			node_sc = create_subcommand('test')
+			node_notify = Literal('notify')
+			node_event = Enumeration('event', NotificationEvent)
+
+			node_sc.then(node_notify)
+			node_notify.then(node_event)
+			node_notify.runs(self.cmd_test_notify)
+			node_event.runs(self.cmd_test_notify)
+			return node_sc
+
 		def make_db_delete_file_cmd():
 			__locate_node(['database']).then(Literal('delete').then(node_subcommand := Literal('file')))
 			node_bid = create_backup_id()
@@ -567,6 +594,7 @@ class CommandManager:
 		root.then(make_import_cmd())
 		root.then(make_list_cmd())
 		root.then(make_tag_cmd())
+		root.then(make_test_cmd())
 		make_db_delete_file_cmd()
 
 		# --------------- done ---------------

--- a/prime_backup/mcdr/task/backup/create_backup_task.py
+++ b/prime_backup/mcdr/task/backup/create_backup_task.py
@@ -12,6 +12,8 @@ from prime_backup.mcdr.text_components import TextComponents
 from prime_backup.types.backup_tags import BackupTags
 from prime_backup.types.operator import Operator
 from prime_backup.utils.timer import Timer
+from prime_backup.utils import notify_utils
+from prime_backup.types.notification_event import NotificationEvent
 
 
 class CreateBackupTask(HeavyTask[Optional[int]]):
@@ -53,49 +55,96 @@ class CreateBackupTask(HeavyTask[Optional[int]]):
 	@override
 	def run(self) -> Optional[int]:
 		self.broadcast(self.tr('start'))
+		notify_utils.notify(
+			NotificationEvent.backup_start,
+			operator=self.operator,
+			source=self.source,
+			extra={
+				'comment': self.comment,
+				'tags': self.backup_tags.to_dict() if self.backup_tags is not None else {},
+			},
+		)
+		backup = None
+		bls = None
+		cost_total = None
+		error: Optional[Exception] = None
+		failure_message: Optional[str] = None
+		succeeded = False
 
-		with contextlib.ExitStack() as exit_stack:
-			exit_stack.enter_context(self.__autosave_disabler())
+		try:
+			with contextlib.ExitStack() as exit_stack:
+				exit_stack.enter_context(self.__autosave_disabler())
 
-			timer = Timer()
-			if self.server.is_server_running():
-				if len(cmd_save_all_worlds := self.config.server.commands.save_all_worlds) > 0:
-					self.server.execute(cmd_save_all_worlds)
-				if len(self.config.server.saved_world_regex) > 0:
-					self.__waiting_world_save = True
-					wait_world_saved_done_ok = self.world_saved_done.wait(timeout=self.config.server.save_world_max_wait.value)
-					self.__waiting_world_save = False
-					if self.aborted_event.is_set():
-						self.broadcast(self.get_aborted_text())
-						return None
-					if not wait_world_saved_done_ok:
-						self.broadcast(self.tr('abort.save_wait_time_out').set_color(RColor.red))
-						return None
-			cost_save_wait = timer.get_and_restart()
-			if self.plugin_unloaded_event.is_set():
-				self.broadcast(self.tr('abort.unloaded').set_color(RColor.red))
-				return None
+				timer = Timer()
+				if self.server.is_server_running():
+					if len(cmd_save_all_worlds := self.config.server.commands.save_all_worlds) > 0:
+						self.server.execute(cmd_save_all_worlds)
+					if len(self.config.server.saved_world_regex) > 0:
+						self.__waiting_world_save = True
+						wait_world_saved_done_ok = self.world_saved_done.wait(timeout=self.config.server.save_world_max_wait.value)
+						self.__waiting_world_save = False
+						if self.aborted_event.is_set():
+							self.broadcast(self.get_aborted_text())
+							failure_message = 'aborted'
+							return None
+						if not wait_world_saved_done_ok:
+							self.broadcast(self.tr('abort.save_wait_time_out').set_color(RColor.red))
+							failure_message = 'save_wait_time_out'
+							return None
+				cost_save_wait = timer.get_and_restart()
+				if self.plugin_unloaded_event.is_set():
+					self.broadcast(self.tr('abort.unloaded').set_color(RColor.red))
+					failure_message = 'plugin_unloaded'
+					return None
 
-			action = CreateBackupAction(self.operator, self.comment, tags=self.backup_tags)
-			backup = action.run()
-			bls = action.get_new_blobs_summary()
-			cost_create = timer.get_elapsed()
-			cost_total = cost_save_wait + cost_create
+				action = CreateBackupAction(self.operator, self.comment, tags=self.backup_tags)
+				backup = action.run()
+				bls = action.get_new_blobs_summary()
+				cost_create = timer.get_elapsed()
+				cost_total = cost_save_wait + cost_create
 
-			self.logger.info('Time costs: save wait {}s, create backup {}s'.format(round(cost_save_wait, 2), round(cost_create, 2)))
-			self.broadcast(self.tr(
-				'completed',
-				TextComponents.backup_id(backup.id),
-				TextComponents.number(f'{round(cost_total, 2)}s').
-				h(self.tr(
-					'cost.hover',
-					TextComponents.number(f'{round(cost_save_wait, 2)}s'),
-					TextComponents.number(f'{round(cost_create, 2)}s')
-				)),
-				TextComponents.backup_size(backup),
-				TextComponents.blob_list_summary_store_size(bls),
-			))
-			return backup.id
+				self.logger.info('Time costs: save wait {}s, create backup {}s'.format(round(cost_save_wait, 2), round(cost_create, 2)))
+				self.broadcast(self.tr(
+					'completed',
+					TextComponents.backup_id(backup.id),
+					TextComponents.number(f'{round(cost_total, 2)}s').
+					h(self.tr(
+						'cost.hover',
+						TextComponents.number(f'{round(cost_save_wait, 2)}s'),
+						TextComponents.number(f'{round(cost_create, 2)}s')
+					)),
+					TextComponents.backup_size(backup),
+					TextComponents.blob_list_summary_store_size(bls),
+				))
+				succeeded = True
+				return backup.id
+		except Exception as e:
+			error = e
+			raise
+		finally:
+			if succeeded and backup is not None:
+				notify_utils.notify(
+					NotificationEvent.backup_success,
+					backup=backup,
+					operator=self.operator,
+					source=self.source,
+					cost_s=cost_total,
+					extra={
+						'new_blobs': {
+							'count': bls.count,
+							'raw_size': bls.raw_size,
+							'stored_size': bls.stored_size,
+						} if bls is not None else {},
+					},
+				)
+			else:
+				notify_utils.notify(
+					NotificationEvent.backup_failure,
+					operator=self.operator,
+					source=self.source,
+					message=failure_message,
+					error=error,
+				)
 
 	@override
 	def on_event(self, event: TaskEvent):

--- a/prime_backup/mcdr/task/backup/restore_backup_task.py
+++ b/prime_backup/mcdr/task/backup/restore_backup_task.py
@@ -16,6 +16,8 @@ from prime_backup.types.operator import Operator, PrimeBackupOperatorNames
 from prime_backup.utils import backup_utils, log_utils
 from prime_backup.utils.mcdr_utils import click_and_run, mkcmd
 from prime_backup.utils.timer import Timer
+from prime_backup.utils import notify_utils
+from prime_backup.types.notification_event import NotificationEvent
 
 
 class RestoreBackupTask(HeavyTask[None]):
@@ -59,67 +61,110 @@ class RestoreBackupTask(HeavyTask[None]):
 
 	@override
 	def run(self):
-		if self.backup_id is None:
-			backup_filter = BackupFilter()
-			backup_filter.requires_non_temporary_backup()
-			candidates = ListBackupAction(backup_filter=backup_filter, limit=1).run()
-			if len(candidates) == 0:
-				self.reply_tr('no_backup')
-				return
-			backup = candidates[0]
-		else:
-			backup = GetBackupAction(self.backup_id).run()
+		restore_backup = None
+		restore_cost = None
+		error: Optional[Exception] = None
+		failure_message: Optional[str] = None
+		succeeded = False
+		try:
+			if self.backup_id is None:
+				backup_filter = BackupFilter()
+				backup_filter.requires_non_temporary_backup()
+				candidates = ListBackupAction(backup_filter=backup_filter, limit=1).run()
+				if len(candidates) == 0:
+					self.reply_tr('no_backup')
+					failure_message = 'no_backup'
+					return
+				backup = candidates[0]
+			else:
+				backup = GetBackupAction(self.backup_id).run()
+			restore_backup = backup
 
-		self.__can_abort = True
-		self.broadcast(self.tr('show_backup', TextComponents.backup_brief(backup)))
-		if self.needs_confirm:
-			if not self.wait_confirm(self.tr('confirm_target')):
-				return
+			self.__can_abort = True
+			self.broadcast(self.tr('show_backup', TextComponents.backup_brief(backup)))
+			if self.needs_confirm:
+				if not self.wait_confirm(self.tr('confirm_target')):
+					failure_message = 'aborted'
+					return
 
-		server_was_running = self.server.is_server_running()
-		if server_was_running:
-			if not self.__countdown_and_stop_server(backup):
-				return
-		else:
-			self.logger.info('Found an already-stopped server')
-		self.__can_abort = False
+			server_was_running = self.server.is_server_running()
+			if server_was_running:
+				if not self.__countdown_and_stop_server(backup):
+					failure_message = 'aborted'
+					return
+			else:
+				self.logger.info('Found an already-stopped server')
+			self.__can_abort = False
 
-		timer = Timer()
-		if self.config.command.backup_on_restore:
-			self.logger.info('Creating backup of existing files to avoid idiot')
-			pre_restore_backup = CreateBackupAction(
-				Operator.pb(PrimeBackupOperatorNames.pre_restore),
-				backup_utils.create_translated_backup_comment('pre_restore', backup.id),
-				tags=BackupTags().set(BackupTagName.temporary, True),
+			notify_utils.notify(
+				NotificationEvent.restore_start,
+				backup=backup,
+				operator=Operator.of(self.source),
+				source=self.source,
+			)
+
+			timer = Timer()
+			if self.config.command.backup_on_restore:
+				self.logger.info('Creating backup of existing files to avoid idiot')
+				pre_restore_backup = CreateBackupAction(
+					Operator.pb(PrimeBackupOperatorNames.pre_restore),
+					backup_utils.create_translated_backup_comment('pre_restore', backup.id),
+					tags=BackupTags().set(BackupTagName.temporary, True),
+				).run()
+				pre_restore_backup_id = f'#{pre_restore_backup.id}'
+			else:
+				pre_restore_backup_id = 'N/A'
+			cost_backup = timer.get_and_restart()
+
+			self.logger.info('Restoring to backup #{} (fail_soft={}, verify_blob={})'.format(backup.id, self.fail_soft, self.verify_blob))
+			failures = ExportBackupToDirectoryAction(
+				backup.id, self.config.source_path,
+				restore_mode=True,
+				fail_soft=self.fail_soft,
+				verify_blob=self.verify_blob,
+				retain_patterns=self.config.backup.retain_patterns,
 			).run()
-			pre_restore_backup_id = f'#{pre_restore_backup.id}'
-		else:
-			pre_restore_backup_id = 'N/A'
-		cost_backup = timer.get_and_restart()
+			cost_restore = timer.get_and_restart()
+			restore_cost = cost_backup + cost_restore
 
-		self.logger.info('Restoring to backup #{} (fail_soft={}, verify_blob={})'.format(backup.id, self.fail_soft, self.verify_blob))
-		failures = ExportBackupToDirectoryAction(
-			backup.id, self.config.source_path,
-			restore_mode=True,
-			fail_soft=self.fail_soft,
-			verify_blob=self.verify_blob,
-			retain_patterns=self.config.backup.retain_patterns,
-		).run()
-		cost_restore = timer.get_and_restart()
-
-		if len(failures) > 0:
-			self.logger.error('Found {} failures during backup export'.format(len(failures)))
-			for line in failures.to_lines():
-				self.logger.error(line.to_colored_text())
-		self.logger.info('Restore to backup #{} done, cost {}s (backup {}s, restore {}s){}'.format(
-			backup.id, round(cost_backup + cost_restore, 2), round(cost_backup, 2), round(cost_restore, 2),
-			', starting the server' if server_was_running else ''
-		))
-
-		if server_was_running:
-			self.server.start()
-
-		with log_utils.open_file_logger('restore') as logger:
-			logger.info('{} restored world to backup #{} (date={}, comment={!r}), pre-restore temp backup: {}'.format(
-				self.source, backup.id, backup.date_str, backup.comment, pre_restore_backup_id,
+			if len(failures) > 0:
+				self.logger.error('Found {} failures during backup export'.format(len(failures)))
+				for line in failures.to_lines():
+					self.logger.error(line.to_colored_text())
+				failure_message = 'export_failures: {}'.format(len(failures))
+			self.logger.info('Restore to backup #{} done, cost {}s (backup {}s, restore {}s){}'.format(
+				backup.id, round(cost_backup + cost_restore, 2), round(cost_backup, 2), round(cost_restore, 2),
+				', starting the server' if server_was_running else ''
 			))
+
+			if len(failures) == 0:
+				succeeded = True
+
+			if server_was_running:
+				self.server.start()
+
+			with log_utils.open_file_logger('restore') as logger:
+				logger.info('{} restored world to backup #{} (date={}, comment={!r}), pre-restore temp backup: {}'.format(
+					self.source, backup.id, backup.date_str, backup.comment, pre_restore_backup_id,
+				))
+		except Exception as e:
+			error = e
+			raise
+		finally:
+			if succeeded:
+				notify_utils.notify(
+					NotificationEvent.restore_success,
+					backup=restore_backup,
+					operator=Operator.of(self.source),
+					source=self.source,
+					cost_s=restore_cost,
+				)
+			else:
+				notify_utils.notify(
+					NotificationEvent.restore_failure,
+					backup=restore_backup,
+					operator=Operator.of(self.source),
+					source=self.source,
+					message=failure_message,
+					error=error,
+				)

--- a/prime_backup/types/notification_event.py
+++ b/prime_backup/types/notification_event.py
@@ -1,0 +1,18 @@
+import enum
+
+
+class NotificationEvent(enum.Enum):
+	backup_start = 'backup_start'
+	backup_success = 'backup_success'
+	backup_failure = 'backup_failure'
+	restore_start = 'restore_start'
+	restore_success = 'restore_success'
+	restore_failure = 'restore_failure'
+
+	@property
+	def task(self) -> str:
+		return self.value.split('_', 1)[0]
+
+	@property
+	def status(self) -> str:
+		return self.value.split('_', 1)[1]

--- a/prime_backup/utils/notify_utils.py
+++ b/prime_backup/utils/notify_utils.py
@@ -1,0 +1,193 @@
+import datetime
+import json
+import time
+import urllib.request
+from typing import Optional, Any, Dict
+
+from prime_backup import constants
+from prime_backup import logger
+from prime_backup.config.config import Config
+from prime_backup.types.backup_info import BackupInfo
+from prime_backup.types.notification_event import NotificationEvent
+from prime_backup.types.operator import Operator
+
+
+def _get_plugin_version() -> str:
+	try:
+		from prime_backup.mcdr import mcdr_globals
+		return mcdr_globals.metadata.version
+	except Exception:
+		try:
+			from prime_backup.cli import cli_utils
+			return cli_utils.get_plugin_version()
+		except Exception:
+			return '?'
+
+
+def _get_server_running() -> Optional[bool]:
+	try:
+		from prime_backup.mcdr import mcdr_globals
+		return mcdr_globals.server.is_server_running()
+	except Exception:
+		return None
+
+
+def _get_source_info(source: Optional[Any]) -> Optional[Dict[str, Any]]:
+	if source is None:
+		return None
+	try:
+		if getattr(source, 'is_player', False):
+			return {
+				'type': 'player',
+				'name': source.player,
+			}
+		if getattr(source, 'is_console', False):
+			return {
+				'type': 'console',
+				'name': '',
+			}
+		return {
+			'type': 'command_source',
+			'name': str(source),
+		}
+	except Exception:
+		return {
+			'type': 'unknown',
+			'name': str(source),
+		}
+
+
+def _backup_to_payload(backup: BackupInfo) -> Dict[str, Any]:
+	return {
+		'id': backup.id,
+		'date': backup.date_str,
+		'comment': backup.comment,
+		'creator': str(backup.creator),
+		'targets': backup.targets,
+		'tags': backup.tags.to_dict(),
+		'file_count': backup.file_count,
+		'raw_size': backup.raw_size,
+		'stored_size': backup.stored_size,
+	}
+
+
+def _operator_to_payload(operator: Operator) -> Dict[str, Any]:
+	return {
+		'type': operator.type,
+		'name': operator.name,
+		'full': str(operator),
+	}
+
+
+def _make_payload(
+		event: NotificationEvent, *,
+		backup: Optional[BackupInfo],
+		operator: Optional[Operator],
+		source: Optional[Any],
+		cost_s: Optional[float],
+		message: Optional[str],
+		error: Optional[Exception],
+		extra: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+	now = time.time()
+	version = str(_get_plugin_version())
+	payload: Dict[str, Any] = {
+		'event': event.value,
+		'task': event.task,
+		'status': event.status,
+		'timestamp': {
+			'unix': now,
+			'iso': datetime.datetime.utcfromtimestamp(now).isoformat() + 'Z',
+		},
+		'plugin': {
+			'id': constants.PLUGIN_ID,
+			'version': version,
+		},
+		'server': {
+			'running': _get_server_running(),
+		},
+	}
+
+	if backup is not None:
+		payload['backup'] = _backup_to_payload(backup)
+	if operator is not None:
+		payload['operator'] = _operator_to_payload(operator)
+	if (src := _get_source_info(source)) is not None:
+		payload['source'] = src
+	if cost_s is not None:
+		payload['cost_s'] = round(cost_s, 3)
+	if message is not None:
+		payload['message'] = message
+	if error is not None:
+		payload['error'] = {
+			'type': error.__class__.__name__,
+			'message': str(error),
+		}
+	if extra is not None:
+		payload['extra'] = extra
+
+	title = f'PrimeBackup {event.task} {event.status}'
+	body_parts = [f'event={event.value}']
+	if backup is not None:
+		body_parts.append(f'backup=#{backup.id}')
+	if message:
+		body_parts.append(f'message={message}')
+	payload['title'] = title
+	payload['body'] = ', '.join(body_parts)
+	payload['desp'] = payload['body']
+	return payload
+
+
+def _post_json(url: str, payload: Dict[str, Any], headers: Dict[str, str], timeout_s: float):
+	data = json.dumps(payload, ensure_ascii=False).encode('utf8')
+	request_headers = {
+		'Content-Type': 'application/json',
+		'User-Agent': f'{constants.PLUGIN_ID}/{_get_plugin_version()}',
+	}
+	request_headers.update(headers)
+	request = urllib.request.Request(url, data=data, headers=request_headers, method='POST')
+	with urllib.request.urlopen(request, timeout=timeout_s) as response:
+		response.read()
+
+
+def notify(
+		event: NotificationEvent, *,
+		backup: Optional[BackupInfo] = None,
+		operator: Optional[Operator] = None,
+		source: Optional[Any] = None,
+		cost_s: Optional[float] = None,
+		message: Optional[str] = None,
+		error: Optional[Exception] = None,
+		extra: Optional[Dict[str, Any]] = None,
+):
+	config = Config.get().notification
+	if not config.enabled:
+		return
+	if event not in config.events:
+		return
+	if len(config.endpoints) == 0:
+		return
+
+	payload = _make_payload(
+		event,
+		backup=backup,
+		operator=operator,
+		source=source,
+		cost_s=cost_s,
+		message=message,
+		error=error,
+		extra=extra,
+	)
+
+	log = logger.get()
+	for endpoint in config.endpoints:
+		if not endpoint.enabled:
+			continue
+		if len(endpoint.url) == 0:
+			log.warning('Notification endpoint {} has empty url, skipped'.format(endpoint.name))
+			continue
+		try:
+			_post_json(endpoint.url, payload, endpoint.headers, endpoint.timeout.value)
+			log.debug('Notification sent to {} for event {}'.format(endpoint.name, event.value))
+		except Exception as e:
+			log.warning('Failed to send notification to {}: {}'.format(endpoint.name, e))

--- a/prime_backup/utils/notify_utils.py
+++ b/prime_backup/utils/notify_utils.py
@@ -150,6 +150,113 @@ def _post_json(url: str, payload: Dict[str, Any], headers: Dict[str, str], timeo
 		response.read()
 
 
+def _apply_if_not_none(data: Dict[str, Any], key: str, value: Any):
+	if value is not None:
+		data[key] = value
+
+
+def _format_bark_body(base_payload: Dict[str, Any], *, markdown: bool) -> str:
+	backup = base_payload.get('backup') or {}
+	operator = base_payload.get('operator') or {}
+	source = base_payload.get('source') or {}
+	error = base_payload.get('error') or {}
+
+	def format_source() -> Optional[str]:
+		src_type = source.get('type')
+		if not src_type:
+			return None
+		src_name = source.get('name') or ''
+		return f'{src_type}:{src_name}' if len(src_name) > 0 else src_type
+
+	fields = [
+		('Event', base_payload.get('event')),
+		('Task', base_payload.get('task')),
+		('Status', base_payload.get('status')),
+		('Backup', f"#{backup.get('id')}" if backup.get('id') is not None else None),
+		('Date', backup.get('date')),
+		('Comment', backup.get('comment')),
+		('Creator', backup.get('creator')),
+		('Operator', operator.get('full')),
+		('Source', format_source()),
+		('Files', (
+			f"{backup.get('file_count')} files, raw={backup.get('raw_size')}, stored={backup.get('stored_size')}"
+			if backup.get('file_count') is not None else None
+		)),
+		('Cost', f"{base_payload.get('cost_s')}s" if base_payload.get('cost_s') is not None else None),
+		('Message', base_payload.get('message')),
+		('Error', (
+			f"{error.get('type')}: {error.get('message')}"
+			if error.get('type') or error.get('message') else None
+		)),
+	]
+
+	if markdown:
+		lines = [f"- **{k}**: {v}" for k, v in fields if v not in [None, '']]
+		return '\n'.join(lines)
+	else:
+		lines = [f"{k}: {v}" for k, v in fields if v not in [None, '']]
+		return '\n'.join(lines)
+
+
+def _resolve_bark_url(endpoint) -> str:
+	url = endpoint.url
+	device_key = getattr(endpoint.bark, 'device_key', None)
+	if device_key:
+		url = url.replace('{device_key}', device_key).replace('{key}', device_key)
+	return url
+
+
+def _make_bark_payload(base_payload: Dict[str, Any], endpoint) -> Dict[str, Any]:
+	bark = endpoint.bark
+	markdown = bool(bark.markdown)
+	default_body = _format_bark_body(base_payload, markdown=markdown)
+	title = bark.title or base_payload.get('title')
+	body = bark.body or default_body
+
+	backup = base_payload.get('backup') or {}
+	backup_id = backup.get('id')
+	if title and backup_id is not None and f'#{backup_id}' not in title:
+		title = f'{title} #{backup_id}'
+
+	data: Dict[str, Any] = {}
+	if markdown:
+		data['markdown'] = body
+	else:
+		data['body'] = body
+	_apply_if_not_none(data, 'title', title)
+	_apply_if_not_none(data, 'subtitle', bark.subtitle)
+
+	if bark.level is None:
+		status = base_payload.get('status')
+		if status == 'failure':
+			data['level'] = 'critical'
+		elif status == 'success':
+			data['level'] = 'passive'
+		else:
+			data['level'] = 'active'
+	else:
+		data['level'] = bark.level
+	_apply_if_not_none(data, 'volume', bark.volume)
+	_apply_if_not_none(data, 'badge', bark.badge)
+	_apply_if_not_none(data, 'call', bark.call)
+	_apply_if_not_none(data, 'autoCopy', bark.autoCopy)
+	_apply_if_not_none(data, 'copy', bark.copy)
+	_apply_if_not_none(data, 'sound', bark.sound)
+	_apply_if_not_none(data, 'icon', bark.icon)
+	_apply_if_not_none(data, 'image', bark.image)
+	_apply_if_not_none(data, 'group', bark.group or constants.PLUGIN_ID)
+	_apply_if_not_none(data, 'url', bark.url)
+	_apply_if_not_none(data, 'action', bark.action)
+	_apply_if_not_none(data, 'id', bark.id)
+	_apply_if_not_none(data, 'delete', bark.delete)
+	_apply_if_not_none(data, 'isArchive', bark.isArchive)
+
+	if bark.device_key and _resolve_bark_url(endpoint).rstrip('/').endswith('/push'):
+		data['device_key'] = bark.device_key
+
+	return data
+
+
 def notify(
 		event: NotificationEvent, *,
 		backup: Optional[BackupInfo] = None,
@@ -187,7 +294,12 @@ def notify(
 			log.warning('Notification endpoint {} has empty url, skipped'.format(endpoint.name))
 			continue
 		try:
-			_post_json(endpoint.url, payload, endpoint.headers, endpoint.timeout.value)
+			if endpoint.type == 'bark':
+				bark_url = _resolve_bark_url(endpoint)
+				bark_payload = _make_bark_payload(payload, endpoint)
+				_post_json(bark_url, bark_payload, endpoint.headers, endpoint.timeout.value)
+			else:
+				_post_json(endpoint.url, payload, endpoint.headers, endpoint.timeout.value)
 			log.debug('Notification sent to {} for event {}'.format(endpoint.name, event.value))
 		except Exception as e:
 			log.warning('Failed to send notification to {}: {}'.format(endpoint.name, e))

--- a/tests/test_notify_utils.py
+++ b/tests/test_notify_utils.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from unittest.mock import patch
 
+from prime_backup.config.notification_config import NotificationEndpoint, BarkOptions
 from prime_backup.types.notification_event import NotificationEvent
 from prime_backup.utils import notify_utils
 
@@ -26,6 +27,57 @@ class NotifyUtilsTestCase(unittest.TestCase):
 			)
 			self.assertEqual('1.2.3', payload['plugin']['version'])
 			json.dumps(payload, ensure_ascii=False)
+
+	def test_bark_payload_support(self):
+		endpoint = NotificationEndpoint(
+			type='bark',
+			url='https://api.day.app/push',
+			bark=BarkOptions(device_key='abc', group='pb', markdown=True),
+		)
+		base_payload = {
+			'title': 'PrimeBackup backup success',
+			'body': 'event=backup_success, backup=#1',
+			'event': 'backup_success',
+			'status': 'success',
+			'task': 'backup',
+			'backup': {
+				'id': 1,
+				'file_count': 10,
+				'raw_size': 100,
+				'stored_size': 80,
+			},
+		}
+		bark_payload = notify_utils._make_bark_payload(base_payload, endpoint)
+		self.assertIn('device_key', bark_payload)
+		self.assertIn('markdown', bark_payload)
+		self.assertNotIn('body', bark_payload)
+		self.assertEqual('pb', bark_payload['group'])
+		self.assertEqual('passive', bark_payload['level'])
+		self.assertIn('backup', bark_payload['markdown'])
+
+	def test_bark_url_placeholder(self):
+		endpoint = NotificationEndpoint(
+			type='bark',
+			url='https://api.day.app/{device_key}',
+			bark=BarkOptions(device_key='xyz'),
+		)
+		url = notify_utils._resolve_bark_url(endpoint)
+		self.assertEqual('https://api.day.app/xyz', url)
+
+	def test_bark_level_default_failure(self):
+		endpoint = NotificationEndpoint(type='bark', url='https://api.day.app/{device_key}', bark=BarkOptions(device_key='xyz'))
+		base_payload = {
+			'title': 'PrimeBackup backup failure',
+			'event': 'backup_failure',
+			'status': 'failure',
+			'task': 'backup',
+			'error': {
+				'type': 'RuntimeError',
+				'message': 'boom',
+			},
+		}
+		bark_payload = notify_utils._make_bark_payload(base_payload, endpoint)
+		self.assertEqual('critical', bark_payload['level'])
 
 
 if __name__ == '__main__':

--- a/tests/test_notify_utils.py
+++ b/tests/test_notify_utils.py
@@ -1,0 +1,32 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from prime_backup.types.notification_event import NotificationEvent
+from prime_backup.utils import notify_utils
+
+
+class _DummyVersion:
+	def __str__(self) -> str:
+		return '1.2.3'
+
+
+class NotifyUtilsTestCase(unittest.TestCase):
+	def test_make_payload_version_json_serializable(self):
+		with patch('prime_backup.utils.notify_utils._get_plugin_version', return_value=_DummyVersion()):
+			payload = notify_utils._make_payload(
+				NotificationEvent.backup_start,
+				backup=None,
+				operator=None,
+				source=None,
+				cost_s=None,
+				message=None,
+				error=None,
+				extra=None,
+			)
+			self.assertEqual('1.2.3', payload['plugin']['version'])
+			json.dumps(payload, ensure_ascii=False)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
**背景**
Prime Backup 在无人值守/自动化运维场景下，缺少“任务开始/成功/失败”的主动通知能力。本 PR 增加可配置的任务通知推送，并提供 Bark 原生支持（无需中转 webhook），同时补齐中英文文档与命令级测试入口，方便快速验证通知链路。
#103 

**变更点**
- 新增任务通知模块：支持在备份/回档任务的 `start/success/failure` 关键节点触发通知。
- 新增通知配置 `notification`：
  - 全局开关 `enabled`、事件过滤 `events`、多端点 `endpoints`。
  - 端点支持 `type = webhook | bark`，默认 `webhook`。
- Webhook 端点：
  - `POST application/json` 发送完整 Prime Backup 通知 payload（包含事件/时间戳/备份信息/操作者/来源/耗时/错误等），并提供 `title/body/desp` 便于第三方直接展示。
- Bark 端点（原生支持，无需中转）：
  - 支持 `https://api.day.app/<key>` 形式，以及 `https://api.day.app/push` + `device_key` JSON 形式。
  - 支持 URL 占位符替换 `{device_key}` / `{key}`。
  - 运维友好正文：默认将关键字段按行输出（可选 markdown）。
  - 默认等级映射（可覆盖）：成功 `passive`、失败 `critical`、开始/其他 `active`。
  - 兼容 Bark 常用参数：`group/sound/level/badge/icon/image/url/action/copy/autoCopy/id/delete/isArchive/...` 等。
- 新增插件内测试命令：`!!pb test notify [event]`，并新增权限项 `command.permission.test`（默认 4）。
- 文档补齐：
  - 新增通知功能页（中英文）与 mkdocs 导航入口。
  - 配置文档补充 `notification` 配置说明与示例；快速开始增加“可选：任务通知推送”入口。

**涉及文档**
- 中文通知文档： notification.zh.md
- 英文通知文档： notification.md
- 配置说明（ZH）： config.zh.md
- 配置说明（EN）： config.md
- 快速开始（ZH）： quick_start.zh.md
- 快速开始（EN）： quick_start.md

**兼容性 / 升级说明**
- 纯增量配置：新增根配置 `notification`，默认关闭，不影响现有用户行为。
- 若用户开启通知：
  - `endpoints[].type` 默认 `webhook`；当 `type = bark` 时改为发送 Bark 原生 JSON 字段（而非完整 Prime Backup payload），这一点已在文档中说明。
  - 配置反序列化时会校验 `endpoints[].type`，非 `webhook/bark` 将报错（用于避免静默配置错误）。
- 命令权限新增：`command.permission.test` 默认为 4，不影响原有命令权限配置。

**备注**
- Bark 推送默认正文与 level 映射面向运维场景；如需自定义展示，可通过 `bark.body` / `bark.markdown` / `bark.level` 覆盖默认行为。
- 部分代码、文档由AI撰写，但均已测试可用。
- 旨在其实只是为了我提的issue https://github.com/TISUnion/PrimeBackup/issues/103 的Webhook运维推送服务提供一个参考，感觉不妥可以拒绝此提交

<img width="603" height="1311" alt="b8093a2cb3fbb77198d94a400d4c77b2" src="https://github.com/user-attachments/assets/514b9872-dfed-4b0a-9007-2536180af323" />
<img width="603" height="1311" alt="ebadd22ea43ff469255e0c4f412d20dd" src="https://github.com/user-attachments/assets/ac0b3d5c-9acc-4ddc-8097-6f15e341b143" />

