### PR TITLE
fix: clickable buttons do nothing on Minecraft 1.20.5+ clients

### DIFF
--- a/prime_backup/mcdr/task/backup/list_backup_task.py
+++ b/prime_backup/mcdr/task/backup/list_backup_task.py
@@ -1,7 +1,7 @@
 import copy
 import json
 
-from mcdreforged.api.all import CommandSource, RText, RTextList, RColor, RStyle, RAction
+from mcdreforged.api.all import CommandSource, RText, RTextList, RColor, RStyle
 from typing_extensions import override
 
 from prime_backup.action.count_backup_action import CountBackupAction
@@ -10,7 +10,7 @@ from prime_backup.mcdr.task.basic_task import LightTask
 from prime_backup.mcdr.text_components import TextComponents
 from prime_backup.types.backup_filter import BackupFilter
 from prime_backup.utils import conversion_utils
-from prime_backup.utils.mcdr_utils import mkcmd
+from prime_backup.utils.mcdr_utils import click_run, mkcmd
 
 
 class ListBackupTask(LightTask[None]):
@@ -72,12 +72,12 @@ class ListBackupTask(LightTask[None]):
 
 		t_prev = RText('<-')
 		if 1 <= self.page - 1 <= max_page:  # has prev
-			t_prev.h(self.tr('prev')).c(RAction.run_command, self.__make_command(self.page - 1))
+			t_prev.h(self.tr('prev')).c(*click_run(self.__make_command(self.page - 1)))
 		else:
 			t_prev.set_color(RColor.dark_gray)
 		t_next = RText('->')
 		if 1 <= self.page + 1 <= max_page:  # has next
-			t_next.h(self.tr('next')).c(RAction.run_command, self.__make_command(self.page + 1))
+			t_next.h(self.tr('next')).c(*click_run(self.__make_command(self.page + 1)))
 		else:
 			t_next.set_color(RColor.dark_gray)
 		self.reply(RTextList(t_prev, ' ', TextComponents.number(self.page), '/', TextComponents.number(max_page), ' ', t_next))

--- a/prime_backup/mcdr/task/crontab/show_crontab_task.py
+++ b/prime_backup/mcdr/task/crontab/show_crontab_task.py
@@ -1,10 +1,10 @@
-from mcdreforged.api.all import RTextBase, RText, RTextList, RColor, RAction
+from mcdreforged.api.all import RTextBase, RText, RTextList, RColor
 from typing_extensions import override
 
 from prime_backup.mcdr.crontab_job.basic_job import BasicCrontabJob
 from prime_backup.mcdr.task.crontab import CrontabTaskBase
 from prime_backup.mcdr.text_components import TextComponents
-from prime_backup.utils.mcdr_utils import mkcmd
+from prime_backup.utils.mcdr_utils import click_run, mkcmd
 
 
 class ShowCrontabJobTask(CrontabTaskBase[None]):
@@ -46,7 +46,7 @@ class ShowCrontabJobTask(CrontabTaskBase[None]):
 				RTextList('[', self.tr(op), ']').
 				set_color(color).
 				h(self.tr(f'{op}.hover', job.get_name_text())).
-				c(RAction.run_command, mkcmd(f'crontab {self.job_id.name} {op}'))
+				c(*click_run(mkcmd(f'crontab {self.job_id.name} {op}')))
 			)
 		buttons = [
 			make('pause', RColor.gold),

--- a/prime_backup/mcdr/task/db/inspect_object_tasks.py
+++ b/prime_backup/mcdr/task/db/inspect_object_tasks.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Callable, Any, Optional
 
-from mcdreforged.api.all import CommandSource, RTextBase, RText, RTextList, RColor, RAction, RTextMCDRTranslation
+from mcdreforged.api.all import CommandSource, RTextBase, RText, RTextList, RColor, RTextMCDRTranslation
 from typing_extensions import override
 
 from prime_backup.action.get_backup_action import GetBackupAction
@@ -24,7 +24,7 @@ from prime_backup.types.chunk_info import ChunkInfo
 from prime_backup.types.file_info import FileInfo
 from prime_backup.types.pack_info import PackInfo
 from prime_backup.utils import platform_utils, chunk_utils, hash_utils, pack_utils
-from prime_backup.utils.mcdr_utils import TranslationContext, mkcmd
+from prime_backup.utils.mcdr_utils import click_run, TranslationContext, mkcmd
 
 
 class _InspectObjectTaskBase(LightTask[None], ABC):
@@ -36,7 +36,7 @@ class _InspectObjectTaskBase(LightTask[None], ABC):
 		return (
 			t_bid.copy()
 			.h(cls.__base_tr.tr('hover.backup_id', t_bid))
-			.c(RAction.run_command, mkcmd(f'database inspect backup {backup_id}'))
+			.c(*click_run(mkcmd(f'database inspect backup {backup_id}')))
 		)
 
 	@classmethod
@@ -45,7 +45,7 @@ class _InspectObjectTaskBase(LightTask[None], ABC):
 		return (
 			t_fsid.copy()
 			.h(cls.__base_tr.tr('hover.fileset_id', t_fsid))
-			.c(RAction.run_command, mkcmd(f'database inspect fileset {fileset_id}'))
+			.c(*click_run(mkcmd(f'database inspect fileset {fileset_id}')))
 		)
 
 	@classmethod
@@ -57,7 +57,7 @@ class _InspectObjectTaskBase(LightTask[None], ABC):
 		return (
 			TextComponents.blob_hash(blob_hash, shorten_hash=shorten_hash).
 			h(cls.__base_tr.tr('blob_hash.hover', RText(blob_hash, TextColors.blob))).
-		    c(RAction.run_command, mkcmd(f'database inspect blob {blob_hash}'))
+		    c(*click_run(mkcmd(f'database inspect blob {blob_hash}')))
 		)
 
 	@classmethod
@@ -65,7 +65,7 @@ class _InspectObjectTaskBase(LightTask[None], ABC):
 		return (
 			TextComponents.chunk_hash(chunk_hash, shorten_hash=shorten_hash).
 			h(cls.__base_tr.tr('chunk_hash.hover', RText(chunk_hash, TextColors.chunk))).
-			c(RAction.run_command, mkcmd(f'database inspect chunk {chunk_hash}'))
+			c(*click_run(mkcmd(f'database inspect chunk {chunk_hash}')))
 		)
 
 	@classmethod
@@ -73,7 +73,7 @@ class _InspectObjectTaskBase(LightTask[None], ABC):
 		return (
 			TextComponents.chunk_group_hash(chunk_group_hash, shorten_hash=shorten_hash).
 			h(cls.__base_tr.tr('chunk_group_hash.hover', RText(chunk_group_hash, TextColors.chunk_group))).
-			c(RAction.run_command, mkcmd(f'database inspect chunk_group {chunk_group_hash}'))
+			c(*click_run(mkcmd(f'database inspect chunk_group {chunk_group_hash}')))
 		)
 
 	@classmethod
@@ -82,7 +82,7 @@ class _InspectObjectTaskBase(LightTask[None], ABC):
 		return (
 			t_name.
 			h(cls.__base_tr.tr('pack_file_name.hover', RText(pack_file_name, TextColors.file))).
-			c(RAction.run_command, mkcmd(f'database inspect pack {pack_id}'))
+			c(*click_run(mkcmd(f'database inspect pack {pack_id}')))
 		)
 
 	@classmethod

--- a/prime_backup/mcdr/text_components.py
+++ b/prime_backup/mcdr/text_components.py
@@ -19,7 +19,7 @@ from prime_backup.types.operator import Operator
 from prime_backup.types.timestamp import Timestamp
 from prime_backup.types.units import ByteCount, Duration
 from prime_backup.utils import conversion_utils, misc_utils, backup_utils
-from prime_backup.utils.mcdr_utils import mkcmd, click_and_run
+from prime_backup.utils.mcdr_utils import click_run, mkcmd, click_and_run
 from prime_backup.utils.path_like import PathLike
 
 
@@ -144,7 +144,7 @@ class TextComponents:
 				hover_lines.append(cls.tr('backup_id.hover_click_hint'))
 			text.h(RTextBase.join('\n', hover_lines))
 		if click:
-			text.c(RAction.run_command, mkcmd(f'show {backup_id}'))
+			text.c(*click_run(mkcmd(f'show {backup_id}')))
 		return text
 
 	@classmethod
@@ -217,7 +217,7 @@ class TextComponents:
 		if suggest:
 			text.h(cls.tr('command.suggest', cmd)).c(RAction.suggest_command, cmd)
 		elif run:
-			text.h(cls.tr('command.run', cmd)).c(RAction.run_command, cmd)
+			text.h(cls.tr('command.run', cmd)).c(*click_run(cmd))
 		return text
 
 	@classmethod

--- a/prime_backup/utils/mcdr_utils.py
+++ b/prime_backup/utils/mcdr_utils.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Union, Any, Tuple
 
 from mcdreforged.api.all import ServerInterface, CommandSource, PlayerCommandSource, ConsoleCommandSource, RTextBase, \
 	RText, RTextList, RColor, RAction
@@ -45,8 +45,25 @@ def broadcast_message(msg: Union[str, RTextBase], *, with_prefix: bool = True):
 	mcdr_globals.server.broadcast(msg)
 
 
+def click_run(command: str) -> Tuple[RAction, str]:
+	"""
+	Build the click event for a command, to be used as ``text.c(*click_run(cmd))``
+
+	Minecraft 1.20.5+ clients refuse to execute a ``run_command`` click event whose command
+	does not start with a ``/``, silently dropping it with
+	``Failed to run command without '/' prefix from click event`` in the client log.
+	MCDR commands (e.g. ``!!pb confirm``) are plain chat messages, so every ``run_command``
+	button of the plugin is a dead button on those clients.
+
+	Fall back to ``suggest_command`` for those, which fills the chat bar with the command
+	so the player only needs to press enter. Real Minecraft commands keep using ``run_command``.
+	"""
+	action = RAction.run_command if command.startswith('/') else RAction.suggest_command
+	return action, command
+
+
 def click_and_run(message: Any, text: Any, command: str) -> RTextBase:
-	return RTextBase.from_any(message).h(text).c(RAction.run_command, command)
+	return RTextBase.from_any(message).h(text).c(*click_run(command))
 
 
 def are_source_same(a: CommandSource, b: CommandSource):


### PR DESCRIPTION
## The problem

Since Minecraft **1.20.5**, the vanilla client refuses to execute a `run_command` click event whose command does not start with a `/`. It drops it silently and logs:

```
Failed to run command without '/' prefix from click event
```

Every clickable button in Prime Backup runs an MCDR command, and MCDR commands are plain chat messages without a leading slash. So on any client from 1.20.5 onwards these are all dead buttons:

- the `√` confirm / `×` abort buttons of the confirmation prompt (`!!pb confirm`, `!!pb abort`) — `text_components.py`, via `click_and_run()`
- the `<-` / `->` pagination of `!!pb list` — `list_backup_task.py`
- clicking a backup id to show it (`!!pb show <id>`) — `text_components.py`
- the `[pause]` / `[resume]` crontab buttons — `show_crontab_task.py`
- all the `!!pb database inspect ...` links — `inspect_object_tasks.py`
- the abort button of an ongoing restore — `restore_backup_task.py`, via `click_and_run()`

In practice this means "Smooth in-game interaction, with most operations achievable through mouse clicks" no longer holds on current versions: players have to type every command by hand. It was reported to me by a player who could not delete a backup because the confirm button did nothing.

## The fix

A single helper, `click_run()` in `prime_backup/utils/mcdr_utils.py`, returns the click event to use for a given command:

```python
def click_run(command: str) -> Tuple[RAction, str]:
	action = RAction.run_command if command.startswith('/') else RAction.suggest_command
	return action, command
```

Used as `text.c(*click_run(cmd))` at the 11 call sites, and inside `click_and_run()`. Commands without a leading `/` fall back to `suggest_command`, which fills the chat bar so the player only needs to press enter; real Minecraft commands keep using `run_command`, so nothing changes for them.

This is deliberately the same interaction the plugin already uses for its `[>]` restore and `[x]` delete buttons in `TextComponents.backup_full()`, so it should feel consistent rather than new.

The last commit also drops the `RAction` imports left unused by the change.

## Notes

- Behaviour on pre-1.20.5 clients is one extra keypress on those buttons. If you would rather keep one-click behaviour there, this could be gated behind a config option or a client-version check, happy to rework it that way.
- Tested on Minecraft 1.21 with MCDR 2.15.5, running the packaged plugin on four servers.
